### PR TITLE
feat: add role verifiable credential to did documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ localnet-start: init-dev export-key
 	NODE0ADDRESS=$(shell go run cmd/poad/main.go cmd/poad/genaccounts.go tendermint show-node-id --home ./build/.poad)@192.16.10.2:26656 docker-compose up
 
 export-key:
-	echo "password1234\npassword1234" | poacli keys export validator 2> ./build/validator
+	echo "password1234\npassword1234" | poacli keys export validator --keyring-backend test 2> ./build/validator
 
 ###############################################################################
 ###                           Helpful Commands	                            ###
@@ -163,16 +163,16 @@ freeze-account:
 ### did module commands
 
 create-did-document:
-	go run cmd/poacli/main.go tx did create-did-document --trust-node --from validator  --chain-id cash
+	go run cmd/poacli/main.go tx did create-did-document --trust-node --from validator  --chain-id cash --keyring-backend test
 
 query-all-did-documents:
 	go run cmd/poacli/main.go query did did-documents --home ./build/.poad --output json | jq
 
 create-verifiable-cred:
-	go run cmd/poacli/main.go tx did create-verifiable-credential --trust-node --from validator  --chain-id cash
+	go run cmd/poacli/main.go tx did create-verifiable-credential $(shell go run cmd/poacli/main.go keys show validator -a --keyring-backend test) --trust-node --from validator  --chain-id cash --keyring-backend test
 
 query-all-verifiable-cred:
-	go run cmd/poacli/main.go query did verifiable-credentials --home ./build/.poad --output json | jq
+	go run cmd/poacli/main.go query did verifiable-credentials  --home ./build/.poad --output json | jq
 
 ### regulators module
 

--- a/app/app.go
+++ b/app/app.go
@@ -189,7 +189,7 @@ func NewInitApp(
 		poa.NewAppModule(app.poaKeeper, app.bankKeeper),
 		issuer.NewAppModule(app.issuerKeeper, app.bankKeeper),
 		did.NewAppModule(app.didKeeper),
-		regulator.NewAppModule(app.regulatorKeeper),
+		regulator.NewAppModule(app.regulatorKeeper, app.didKeeper),
 	)
 
 	app.mm.SetOrderEndBlockers(poatypes.ModuleName)

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -78,8 +78,8 @@ func GetCmdCreateDidDocument(cdc *codec.Codec) *cobra.Command {
 func GetCmdCreateVerifiableCredential(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "create-verifiable-credential [address]",
-		Short: "create an did document for an address",
-		Args:  cobra.ExactArgs(0),
+		Short: "create an verifiable cred for an address",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			inBuf := bufio.NewReader(cmd.InOrStdin())
@@ -92,7 +92,7 @@ func GetCmdCreateVerifiableCredential(cdc *codec.Codec) *cobra.Command {
 			accAddr := cliCtx.GetFromAddress()
 			id := types.DidIdentifer + accAddr.String()
 
-			msg := types.NewMsgCreateVerifiableCredential(types.VcContext, id, "VerifiableCredential", accAddr.String(), types.Proof{}, accAddr)
+			msg := types.NewMsgCreateVerifiableCredential(types.DidIdentifer+args[0], types.VcContext, id, "VerifiableCredential", accAddr.String(), types.Proof{}, accAddr)
 			err := msg.ValidateBasic()
 			if err != nil {
 				return err

--- a/x/did/keeper/document.go
+++ b/x/did/keeper/document.go
@@ -21,5 +21,9 @@ func (k Keeper) UnmarshalDidDocument(value []byte) (interface{}, bool) {
 		return types.DidDocument{}, false
 	}
 
+	if document.Context == "" {
+		return types.DidDocument{}, false
+	}
+
 	return document, true
 }

--- a/x/did/types/msg_create_verifiable_credential.go
+++ b/x/did/types/msg_create_verifiable_credential.go
@@ -7,17 +7,19 @@ import (
 
 // Verifiable Credential message
 type MsgCreateVerifiableCredential struct {
-	Context string `json:"@context"`
-	ID      string `json:"id"`
-	VcType  string `json:"type"`
-	Issuer  string `json:"issuer"`
-	// TODO: CredentialSubject interface{} `json:credentialsubject`
-	Proof Proof          `json:"proof"`
-	Owner sdk.AccAddress `json:"owner"`
+	DidUrl            string            `json:"didurl"`
+	Context           string            `json:"@context"`
+	ID                string            `json:"id"`
+	VcType            string            `json:"type"`
+	Issuer            string            `json:"issuer"`
+	CredentialSubject CredentialSubject `json:"credentialsubject"`
+	Proof             Proof             `json:"proof"`
+	Owner             sdk.AccAddress    `json:"owner"`
 }
 
-func NewMsgCreateVerifiableCredential(context string, id string, vctype string, issuer string, proof Proof, owner sdk.AccAddress) MsgCreateVerifiableCredential {
+func NewMsgCreateVerifiableCredential(didurl string, context string, id string, vctype string, issuer string, proof Proof, owner sdk.AccAddress) MsgCreateVerifiableCredential {
 	return MsgCreateVerifiableCredential{
+		DidUrl:  didurl,
 		Context: context,
 		ID:      id,
 		VcType:  vctype,

--- a/x/did/types/verifiable_credentials.go
+++ b/x/did/types/verifiable_credentials.go
@@ -34,21 +34,34 @@ definition: https://www.w3.org/TR/vc-data-model/#zero-knowledge-proofs
 */
 
 type VerifiableCredential struct {
-	Context string `json:"@context"`
-	ID      string `json:"id"`
-	Type    string `json:"type"`
-	Issuer  string `json:"issuer"`
-	// TODO: CredentialSubject interface{} `json:credentialsubject`
-	Proof Proof `json:proof`
+	Context           string            `json:"@context"`
+	ID                string            `json:"id"`
+	Type              string            `json:"type"`
+	Issuer            string            `json:"issuer"`
+	CredentialSubject CredentialSubject `json:"credentialsubject"`
+	Proof             Proof             `json:"proof"`
 }
 
-func NewVerifiableCredential(context string, id string, vctype string, issuer string, proof Proof) VerifiableCredential {
+func NewVerifiableCredential(context string, id string, vctype string, issuer string, credentialSubject CredentialSubject, proof Proof) VerifiableCredential {
 	return VerifiableCredential{
-		Context: context,
-		ID:      id,
-		Type:    vctype,
-		Issuer:  issuer,
-		Proof:   proof,
+		Context:           context,
+		ID:                id,
+		Type:              vctype,
+		Issuer:            issuer,
+		CredentialSubject: credentialSubject,
+		Proof:             proof,
+	}
+}
+
+type CredentialSubject struct {
+	Role       string `json:"role"`
+	IsVerified bool   `json:"isverified"`
+}
+
+func NewCredentialSubject(role string, isVerified bool) CredentialSubject {
+	return CredentialSubject{
+		Role:       role,
+		IsVerified: isVerified,
 	}
 }
 
@@ -69,5 +82,3 @@ func NewProof(ptype string, issuerData string, attributes string, signature stri
 		SignatureCorrectnessProof: signatureProof,
 	}
 }
-
-// TODO: CredentialSchema

--- a/x/regulator/genesis.go
+++ b/x/regulator/genesis.go
@@ -1,7 +1,6 @@
 package regulator
 
 import (
-	"fmt"
 	"github.com/allinbits/cosmos-cash-poa/x/regulator/keeper"
 	"github.com/allinbits/cosmos-cash-poa/x/regulator/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,7 +12,6 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, data authtypes.GenesisState) {
 	// To keep the module simple we set all genesis accounts as regualtors
 	for _, account := range data.Accounts {
-		fmt.Println(account)
 		reg := types.NewRegulator(account.GetAddress())
 		k.SetRegulator(ctx, []byte(account.GetAddress()), reg)
 	}

--- a/x/regulator/module.go
+++ b/x/regulator/module.go
@@ -8,6 +8,7 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
+	didkeeper "github.com/allinbits/cosmos-cash-poa/x/did/keeper"
 	"github.com/allinbits/cosmos-cash-poa/x/regulator/client/cli"
 	"github.com/allinbits/cosmos-cash-poa/x/regulator/client/rest"
 	"github.com/allinbits/cosmos-cash-poa/x/regulator/keeper"
@@ -74,15 +75,17 @@ func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
 type AppModule struct {
 	AppModuleBasic
 
-	keeper keeper.Keeper
+	keeper         keeper.Keeper
+	IdentityKeeper didkeeper.Keeper
 	// TODO: Add keepers that your application depends on
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(k keeper.Keeper /*TODO: Add Keepers that your application depends on*/) AppModule {
+func NewAppModule(k keeper.Keeper, dk didkeeper.Keeper) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{},
 		keeper:         k,
+		IdentityKeeper: dk,
 		// TODO: Add keepers that your application depends on
 	}
 }


### PR DESCRIPTION
### Description

Added role verifiable credential to the identity document

### How to test

- `make start-dev`
- `make make create-did-document`
- `make create-verifiable-cred`
- `make query-all-did-documents`
- `make query-all-verifiable-cred`

####' Output
```json
[
  {
    "@context": "https://www.w3.org/ns/did/v1",
    "id": "did:cosmos:cosmos1y0hcs6j0n4f89a39uetpngvjmvqwzrlre4y4u6",
    "authentication": [
      {
        "id": "did:cosmos:cosmos1y0hcs6j0n4f89a39uetpngvjmvqwzrlre4y4u6",
        "type": "Ed25519VerificationKey2018",
        "controller": "cosmos1y0hcs6j0n4f89a39uetpngvjmvqwzrlre4y4u6",
        "publicKeyBase58": "23EF886A4F9D5272F625E65619A192DB00E10FE3"
      }
    ],
    "service": [
      {
        "id": "cosmos1y0hcs6j0n4f89a39uetpngvjmvqwzrlre4y4u6did:cosmos:cosmos1y0hcs6j0n4f89a39uetpngvjmvqwzrlre4y4u6",
        "type": "role",
        "serviceEndpoint": "cash-bc"
      }
    ]
  }
]

```